### PR TITLE
Avoid dataloader worker hangs in HIBEAM training

### DIFF
--- a/HIBEAM/HIBEAM_GNN_v5.py
+++ b/HIBEAM/HIBEAM_GNN_v5.py
@@ -53,6 +53,7 @@ from hibeam_det import HIBEAM_Detector
 BATCH_SIZE = 64
 MAX_EPOCHS = 1 #30
 GPUS = [0]         # []=CPU, [0] 用第一張 GPU
+NUM_WORKERS = 0    # 資料讀取進程數（0=單線程，可避免 multiprocessing 卡住）
 USE_TIME = True    # 使用 dom_t 特徵
 AUTO_VIZ = False   # 訓練+推論之後，是否自動畫圖（XY/ZY）
 N_VIZ_EACH = 20    # 每個 res_tag 隨機可視化的事件數
@@ -618,15 +619,12 @@ def train_and_eval_for_dir(
         },
         train_dataloader_kwargs={
             "batch_size": BATCH_SIZE,
-            "num_workers": 2,
-            "persistent_workers": False,
+            "num_workers": NUM_WORKERS,
+            "persistent_workers": NUM_WORKERS > 0,
             "pin_memory": False,
             "shuffle": True,
         },
     )
-
-    train_loader = dm.train_dataloader
-    val_loader = dm.val_dataloader
 
     model = MultiTrackModel(
         graph_definition=graph_definition,
@@ -647,7 +645,7 @@ def train_and_eval_for_dir(
         enable_checkpointing=False,
         deterministic=False,
     )
-    trainer.fit(model, train_loader, val_loader)
+    trainer.fit(model, datamodule=dm)
 
     # --------- Prediction（event/candidate/track 三表） ---------
     inference_and_export_tracks(model, pred_dir, out_dir=out_root/"event_level_information/", use_time=use_time, graph_definition=graph_definition)
@@ -715,7 +713,13 @@ def inference_and_export_tracks(model: MultiTrackModel, data_dir: str, out_dir: 
         graph_definition=graph_definition,
         index_column="event_id",
     )
-    loader = PyGDataLoader(dataset, batch_size=BATCH_SIZE, shuffle=False, num_workers=2, persistent_workers=False)
+    loader = PyGDataLoader(
+        dataset,
+        batch_size=BATCH_SIZE,
+        shuffle=False,
+        num_workers=NUM_WORKERS,
+        persistent_workers=NUM_WORKERS > 0,
+    )
 
     ms_cfg = model.multiscale_cfg
 


### PR DESCRIPTION
## Summary
- add a shared NUM_WORKERS constant so all loaders default to single-threaded loading
- reuse the GraphNeT data module directly with Trainer.fit and apply the worker limit to inference loading to prevent multiprocessing hangs

## Testing
- not run (HIBEAM datasets are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2e22737d4832da622aaa3db6fb678